### PR TITLE
Extract member variables with JavaParser

### DIFF
--- a/app/src/main/java/de/epischel/javamember/MemberVariableExtractor.java
+++ b/app/src/main/java/de/epischel/javamember/MemberVariableExtractor.java
@@ -1,0 +1,32 @@
+package de.epischel.javamember;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utility to extract all member variable names from a parsed Java class.
+ */
+public class MemberVariableExtractor {
+
+    private MemberVariableExtractor() {
+        // utility class
+    }
+
+    /**
+     * Returns the names of all member variables declared in the given compilation unit.
+     *
+     * @param cu parsed compilation unit of a Java source file
+     * @return list of member variable names in declaration order
+     */
+    public static List<String> getMemberVariableNames(CompilationUnit cu) {
+        return cu.findAll(FieldDeclaration.class).stream()
+                .flatMap(fd -> fd.getVariables().stream())
+                .map(VariableDeclarator::getNameAsString)
+                .collect(Collectors.toList());
+    }
+}
+

--- a/app/src/test/java/de/epischel/javamember/MemberVariableExtractorTest.java
+++ b/app/src/test/java/de/epischel/javamember/MemberVariableExtractorTest.java
@@ -1,0 +1,31 @@
+package de.epischel.javamember;
+
+import com.github.javaparser.ast.CompilationUnit;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MemberVariableExtractorTest {
+
+    @Test
+    void extractsMemberVariables() throws Exception {
+        String source = """
+                class Sample {
+                    private int a;
+                    String b, c;
+                    static final double PI = 3.14;
+                    void method() { int local = 0; }
+                }
+                """;
+        Path temp = Files.createTempFile("Sample", ".java");
+        Files.writeString(temp, source);
+        CompilationUnit cu = App.parseFile(temp);
+        List<String> vars = MemberVariableExtractor.getMemberVariableNames(cu);
+        assertEquals(List.of("a", "b", "c", "PI"), vars);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `MemberVariableExtractor` to list member variable names from a parsed class
- test field extraction against multiple declarations

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a62baf7f888327878d38357bb2e717