### PR TITLE
feat: find member variable usage in class methods

### DIFF
--- a/app/src/main/java/de/epischel/javamember/MemberUsageFinder.java
+++ b/app/src/main/java/de/epischel/javamember/MemberUsageFinder.java
@@ -1,0 +1,62 @@
+package de.epischel.javamember;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utility to find methods of a class that use a given member variable.
+ */
+public class MemberUsageFinder {
+
+    private MemberUsageFinder() {
+        // utility class
+    }
+
+    /**
+     * Returns all methods in the primary class of the given compilation unit
+     * that reference the specified member variable. The returned declarations allow
+     * callers to inspect the full method signature, which is important when methods
+     * are overloaded.
+     *
+     * @param cu       parsed compilation unit of a Java source file
+     * @param variable name of the member variable to search for
+     * @return list of method declarations that use the member variable
+     */
+    public static List<MethodDeclaration> findUsage(CompilationUnit cu, String variable) {
+        return cu.findFirst(ClassOrInterfaceDeclaration.class)
+                .map(clazz -> clazz.getMethods().stream()
+                        .filter(m -> usesVariable(m, variable))
+                        .collect(Collectors.toList()))
+                .orElse(List.of());
+    }
+
+    private static boolean usesVariable(MethodDeclaration method, String variable) {
+        boolean hasLocal = method.getParameters().stream()
+                .anyMatch(p -> p.getNameAsString().equals(variable))
+                || method.findAll(VariableDeclarator.class).stream()
+                .anyMatch(vd -> vd.getNameAsString().equals(variable));
+
+        String className = method.findAncestor(ClassOrInterfaceDeclaration.class)
+                .map(ClassOrInterfaceDeclaration::getNameAsString)
+                .orElse("");
+
+        boolean uses = method.findAll(FieldAccessExpr.class).stream()
+                .anyMatch(fa -> fa.getNameAsString().equals(variable)
+                        && (fa.getScope().isThisExpr()
+                        || fa.getScope().toString().equals(className)));
+
+        if (!hasLocal) {
+            uses = uses || method.findAll(NameExpr.class).stream()
+                    .anyMatch(ne -> ne.getNameAsString().equals(variable));
+        }
+        return uses;
+    }
+}
+

--- a/app/src/test/java/de/epischel/javamember/MemberUsageFinderTest.java
+++ b/app/src/test/java/de/epischel/javamember/MemberUsageFinderTest.java
@@ -1,0 +1,50 @@
+package de.epischel.javamember;
+
+import com.github.javaparser.ast.CompilationUnit;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MemberUsageFinderTest {
+
+    @Test
+    void findsMethodsUsingVariable() throws Exception {
+        String source = """
+                class Sample {
+                    private int a;
+                    private int b;
+
+                    void foo() { a = 1; }
+                    void bar(int a) { this.a = a; }
+                    void bar() { a = 2; }
+                    void baz() { int a = 0; }
+                    void useOther(Sample other) { other.a++; }
+                    void qux() { b++; }
+                    void quux(int b) { this.b = b; }
+                    void noUse() {}
+                }
+                """;
+        Path temp = Files.createTempFile("Sample", ".java");
+        Files.writeString(temp, source);
+        CompilationUnit cu = App.parseFile(temp);
+        List<String> aUsage = MemberUsageFinder.findUsage(cu, "a").stream()
+                .map(m -> m.getSignature().asString())
+                .collect(Collectors.toList());
+        List<String> bUsage = MemberUsageFinder.findUsage(cu, "b").stream()
+                .map(m -> m.getSignature().asString())
+                .collect(Collectors.toList());
+        List<String> cUsage = MemberUsageFinder.findUsage(cu, "c").stream()
+                .map(m -> m.getSignature().asString())
+                .collect(Collectors.toList());
+
+        assertEquals(List.of("foo()", "bar(int)", "bar()"), aUsage);
+        assertEquals(List.of("qux()", "quux(int)"), bUsage);
+        assertEquals(List.of(), cUsage);
+    }
+}
+


### PR DESCRIPTION
## Summary
- return `MethodDeclaration` objects so method signatures are preserved
- ignore references to similarly named fields on other objects
- expand tests to cover method overloading and non-member field usage

## Testing
- `bash ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a62e296fa083278ee3c408e4de5d83