### PR TITLE
Compute transitive member usage

### DIFF
--- a/app/src/main/java/de/epischel/javamember/MemberUsageFinder.java
+++ b/app/src/main/java/de/epischel/javamember/MemberUsageFinder.java
@@ -5,9 +5,17 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -20,21 +28,84 @@ public class MemberUsageFinder {
     }
 
     /**
-     * Returns all methods in the primary class of the given compilation unit
-     * that reference the specified member variable. The returned declarations allow
-     * callers to inspect the full method signature, which is important when methods
-     * are overloaded.
+     * Returns all methods in the primary class of the given compilation unit that
+     * either access the specified member variable directly or invoke another method
+     * (recursively) that does. The returned declarations allow callers to inspect
+     * the full method signature, which is important when methods are overloaded.
      *
      * @param cu       parsed compilation unit of a Java source file
      * @param variable name of the member variable to search for
-     * @return list of method declarations that use the member variable
+     * @return list of method declarations that eventually use the member variable
      */
     public static List<MethodDeclaration> findUsage(CompilationUnit cu, String variable) {
         return cu.findFirst(ClassOrInterfaceDeclaration.class)
-                .map(clazz -> clazz.getMethods().stream()
-                        .filter(m -> usesVariable(m, variable))
-                        .collect(Collectors.toList()))
+                .map(clazz -> {
+                    List<MethodDeclaration> methods = clazz.getMethods();
+                    Map<MethodDeclaration, Set<MethodDeclaration>> callGraph = buildCallGraph(clazz);
+                    Map<MethodDeclaration, Set<MethodDeclaration>> callers = invert(callGraph);
+
+                    Set<MethodDeclaration> result = new HashSet<>();
+                    Deque<MethodDeclaration> stack = new ArrayDeque<>();
+
+                    for (MethodDeclaration m : methods) {
+                        if (usesVariable(m, variable)) {
+                            result.add(m);
+                            stack.push(m);
+                        }
+                    }
+
+                    while (!stack.isEmpty()) {
+                        MethodDeclaration current = stack.pop();
+                        for (MethodDeclaration caller : callers.getOrDefault(current, Set.of())) {
+                            if (result.add(caller)) {
+                                stack.push(caller);
+                            }
+                        }
+                    }
+
+                    return methods.stream()
+                            .filter(result::contains)
+                            .collect(Collectors.toList());
+                })
                 .orElse(List.of());
+    }
+
+    private static Map<MethodDeclaration, Set<MethodDeclaration>> buildCallGraph(ClassOrInterfaceDeclaration clazz) {
+        List<MethodDeclaration> methods = clazz.getMethods();
+        Map<MethodDeclaration, Set<MethodDeclaration>> graph = new HashMap<>();
+        for (MethodDeclaration caller : methods) {
+            Set<MethodDeclaration> callees = caller.findAll(MethodCallExpr.class).stream()
+                    .map(call -> resolveCall(call, clazz, methods))
+                    .flatMap(Optional::stream)
+                    .collect(Collectors.toSet());
+            graph.put(caller, callees);
+        }
+        return graph;
+    }
+
+    private static Map<MethodDeclaration, Set<MethodDeclaration>> invert(Map<MethodDeclaration, Set<MethodDeclaration>> graph) {
+        Map<MethodDeclaration, Set<MethodDeclaration>> callers = new HashMap<>();
+        for (Map.Entry<MethodDeclaration, Set<MethodDeclaration>> entry : graph.entrySet()) {
+            MethodDeclaration caller = entry.getKey();
+            for (MethodDeclaration callee : entry.getValue()) {
+                callers.computeIfAbsent(callee, k -> new HashSet<>()).add(caller);
+            }
+        }
+        return callers;
+    }
+
+    private static Optional<MethodDeclaration> resolveCall(MethodCallExpr call, ClassOrInterfaceDeclaration clazz, List<MethodDeclaration> methods) {
+        if (call.getScope().isPresent()) {
+            var scope = call.getScope().get();
+            if (!(scope.isThisExpr() || scope.toString().equals(clazz.getNameAsString()))) {
+                return Optional.empty();
+            }
+        }
+        String name = call.getNameAsString();
+        int argCount = call.getArguments().size();
+        return methods.stream()
+                .filter(m -> m.getNameAsString().equals(name) && m.getParameters().size() == argCount)
+                .findFirst();
     }
 
     private static boolean usesVariable(MethodDeclaration method, String variable) {

--- a/app/src/test/java/de/epischel/javamember/AppUsageOutputTest.java
+++ b/app/src/test/java/de/epischel/javamember/AppUsageOutputTest.java
@@ -22,8 +22,10 @@ class AppUsageOutputTest {
                     void foo() { a = 1; }
                     void bar(int a) { this.a = a; }
                     void bar() { a = 2; }
+                    void callFoo() { foo(); }
                     void qux() { b++; }
                     void quux(int b) { this.b = b; }
+                    void callQux() { qux(); }
                     void noUse() {}
                 }
                 """;
@@ -41,8 +43,8 @@ class AppUsageOutputTest {
         }
 
         String expected = String.join(System.lineSeparator(),
-                "a: foo(), bar(int), bar()",
-                "b: qux(), quux(int)",
+                "a: foo(), bar(int), bar(), callFoo()",
+                "b: qux(), quux(int), callQux()",
                 "c:") + System.lineSeparator();
 
         assertEquals(expected, out.toString());

--- a/app/src/test/java/de/epischel/javamember/MemberUsageFinderTest.java
+++ b/app/src/test/java/de/epischel/javamember/MemberUsageFinderTest.java
@@ -24,8 +24,11 @@ class MemberUsageFinderTest {
                     void bar() { a = 2; }
                     void baz() { int a = 0; }
                     void useOther(Sample other) { other.a++; }
+                    void callFoo() { foo(); }
+                    void callCallFoo() { callFoo(); }
                     void qux() { b++; }
                     void quux(int b) { this.b = b; }
+                    void callQux() { qux(); }
                     void noUse() {}
                 }
                 """;
@@ -42,8 +45,8 @@ class MemberUsageFinderTest {
                 .map(m -> m.getSignature().asString())
                 .collect(Collectors.toList());
 
-        assertEquals(List.of("foo()", "bar(int)", "bar()"), aUsage);
-        assertEquals(List.of("qux()", "quux(int)"), bUsage);
+        assertEquals(List.of("foo()", "bar(int)", "bar()", "callFoo()", "callCallFoo()"), aUsage);
+        assertEquals(List.of("qux()", "quux(int)", "callQux()"), bUsage);
         assertEquals(List.of(), cUsage);
     }
 }


### PR DESCRIPTION
## Summary
- track methods that call others to build a transitive closure of member variable usage
- extend sample tests to verify methods reachable through calls are reported

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a76a76294c8327a20867682f250a65